### PR TITLE
Add hugo engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
  - 1.7.3
 
 before_install:
+  - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls
   - go get github.com/tools/godep
 
@@ -12,5 +13,7 @@ install:
   - godep restore
 
 script:
- - cd handlers
- - $HOME/gopath/bin/goveralls -service=travis-ci
+ - go test -coverprofile=handlers.coverprofile ./handlers
+ - go test -coverprofile=hugo.coverprofile ./hugo
+ - $HOME/gopath/bin/gover
+ - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci

--- a/hugo/hugo.go
+++ b/hugo/hugo.go
@@ -1,0 +1,42 @@
+package hugo
+
+import (
+	"os/exec"
+)
+
+const (
+	hugoCommand = "hugo"
+)
+
+// Runner is something that runs. In our case the command executor that runs.
+type Runner interface {
+	Run() error
+}
+
+// Executor is something that executes. In this case an executor execute a
+// command with given arguments.
+type Executor interface {
+	Execute(string, []string) Runner
+}
+
+// CommandExecutor is the command executor in the command line.
+type CommandExecutor struct{}
+
+// BuildSite builds an hugo project using the command line hugo tool. In the
+// future a library use should be studied. Maybe this is better to be done when
+// the HUGO project gets a more usable API.
+func BuildSite(command string, source string, commandExecutor Executor) error {
+	arguments := []string{"--source", source}
+	runner := commandExecutor.Execute(command, arguments)
+	err := runner.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute executes a command line command. It does not run it. It returns a
+// runner that can run the command.
+func (c *CommandExecutor) Execute(command string, arguments []string) Runner {
+	return exec.Command(command, arguments...)
+}

--- a/hugo/hugo_suite_test.go
+++ b/hugo/hugo_suite_test.go
@@ -1,0 +1,13 @@
+package hugo_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHugo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hugo Suite")
+}

--- a/hugo/hugo_test.go
+++ b/hugo/hugo_test.go
@@ -1,0 +1,29 @@
+package hugo_test
+
+import (
+	hugo "github.com/joaodias/hugito-app/hugo"
+	"github.com/joaodias/hugito-app/mocks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hugo", func() {
+	Describe("When building an HUGO website", func() {
+		Context("and there is a problem with the command or the argumet", func() {
+			It("should return an error", func() {
+				commandExecutor := &mocks.CommandExecutor{
+					IsError: true,
+				}
+				Expect(hugo.BuildSite("stupidCommand", "badDirectory", commandExecutor).Error()).To(Equal("Error building HUGO site."))
+			})
+		})
+		Context("and the website is successfully built", func() {
+			It("should return no error", func() {
+				commandExecutor := &mocks.CommandExecutor{
+					IsError: false,
+				}
+				Expect(hugo.BuildSite("stupidCommand", "badDirectory", commandExecutor)).To(BeNil())
+			})
+		})
+	})
+})

--- a/mocks/hugo_mock.go
+++ b/mocks/hugo_mock.go
@@ -1,0 +1,32 @@
+package mocks
+
+import (
+	"errors"
+	"github.com/joaodias/hugito-app/hugo"
+)
+
+type CommandRunner struct {
+	IsError bool
+}
+
+type CommandExecutor struct {
+	IsError bool
+}
+
+func (c *CommandExecutor) Execute(cmd string, args []string) hugo.Runner {
+	if c.IsError {
+		return &CommandRunner{
+			IsError: true,
+		}
+	}
+	return &CommandRunner{
+		IsError: false,
+	}
+}
+
+func (c *CommandRunner) Run() error {
+	if c.IsError {
+		return errors.New("Error building HUGO site.")
+	}
+	return nil
+}


### PR DESCRIPTION
Hugo engine build added via command executor. This means that hugo should be installed in the deploy environment. After a bit of trial I reached the conclusion that for the time being this should be the better solution. Hugo does not necessarly has a clear API so the command execution is much simpler and wraps some of the problems I was having using the API.

Closes #74